### PR TITLE
chore: fix yaml formatting

### DIFF
--- a/.github/sync-repo-settings.yaml
+++ b/.github/sync-repo-settings.yaml
@@ -25,7 +25,7 @@ branchProtectionRules:
   requiredStatusCheckContexts:
     - 'cla/google'
     - 'snippet-bot check'
-    - 'snippet-bot check
+    - 'snippet-bot check'
   requiredApprovingReviewCount: 1
   requiresCodeOwnerReviews: true
 - pattern: master

--- a/.github/sync-repo-settings.yaml
+++ b/.github/sync-repo-settings.yaml
@@ -35,5 +35,5 @@ branchProtectionRules:
     - 'cla/google'
     - 'snippet-bot check'
     - 'header-check'
-  requisnippet-bot checkwCount: 1
+  requiredApprovingReviewCount: 1
   requiresCodeOwnerReviews: true


### PR DESCRIPTION
There's an unmatched `'` which is causing the sync-repo-settings bot to fail to parse this file.
Also, there was a weird copy/paste typo.